### PR TITLE
refactor!: :pencil2: fix capitalisation of cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ npm install @orama/cloudflare-api
 ## Usage
 
 ```ts
-import { CloudFlareApi } from '@orama/cloudflare-api';
+import { CloudflareApi } from '@orama/cloudflare-api';
 
 const apiKey = 'your-api-key'
-const api = new CloudFlareApi({ apiKey })
+const api = new CloudflareApi({ apiKey })
 
 // Worker KV
 const ACCOUNT_ID = 'your-account-id'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,23 @@
-import { CloudFlareApiConfig } from './internal_types.js'
-import { CloudFlareWorkerKv } from './workerKv.js'
+import { CloudflareApiConfig } from './internal_types.js'
+import { CloudflareWorkerKv } from './workerKv.js'
 
-export interface CloudFlareApiOption {
+export interface CloudflareApiOption {
   apiKey: string
   url?: string
 }
 
-export class CloudFlareApi {
-  private readonly config: CloudFlareApiConfig
+export class CloudflareApi {
+  private readonly config: CloudflareApiConfig
 
-  constructor (option: CloudFlareApiOption) {
+  constructor (option: CloudflareApiOption) {
     this.config = {
       apiKey: option.apiKey,
       url: option.url ?? 'https://api.cloudflare.com/client/v4'
     }
   }
 
-  workerKv (accountId: string, namespaceId: string): CloudFlareWorkerKv {
-    return new CloudFlareWorkerKv({
+  workerKv (accountId: string, namespaceId: string): CloudflareWorkerKv {
+    return new CloudflareWorkerKv({
       ...this.config,
       accountId,
       namespaceId

--- a/src/internal_types.ts
+++ b/src/internal_types.ts
@@ -1,5 +1,5 @@
 
-export interface CloudFlareApiConfig {
+export interface CloudflareApiConfig {
   apiKey: string
   url: string
 }

--- a/src/workerKv.ts
+++ b/src/workerKv.ts
@@ -1,7 +1,7 @@
-import { CloudFlareApiConfig, Method } from './internal_types.js'
+import { CloudflareApiConfig, Method } from './internal_types.js'
 import { checkSuccess, createError, makeHttpRequest } from './utils.js'
 
-export interface CloudFlareWorkerKvConfig extends CloudFlareApiConfig {
+export interface CloudflareWorkerKvConfig extends CloudflareApiConfig {
   accountId: string
   namespaceId: string
 }
@@ -16,8 +16,8 @@ type ReturnAsType<T> =
             T extends 'response' ? Response :
               never
 
-export class CloudFlareWorkerKv {
-  constructor (private readonly config: CloudFlareWorkerKvConfig) {}
+export class CloudflareWorkerKv {
+  constructor (private readonly config: CloudflareWorkerKvConfig) {}
 
   async getKv<T extends ReturnAs>(key: string, returnAs: T): Promise<ReturnAsType<T>> {
     const response = await this.perform(Method.GET, key, undefined)

--- a/tests/deleteKV.test.ts
+++ b/tests/deleteKV.test.ts
@@ -1,8 +1,8 @@
 import t from 'node:test'
 import assert from 'node:assert'
 
-import { CloudFlareApi } from '../src/index.js'
-import { buildFakeCloudFlareServer } from './helper.js'
+import { CloudflareApi } from '../src/index.js'
+import { buildFakeCloudflareServer } from './helper.js'
 
 const API_KEY = 'a-fake-api-key'
 const ACCOUNT_ID = '123'
@@ -11,10 +11,10 @@ const KEY = '789'
 
 await t.test('deleteKv', async (t) => {
   await t.test('should delete kv', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: true })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await workerKv.deleteKv(KEY)
@@ -24,10 +24,10 @@ await t.test('deleteKv', async (t) => {
   })
 
   await t.test('should throw an error on success: false', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: false })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {
@@ -39,10 +39,10 @@ await t.test('deleteKv', async (t) => {
   })
 
   await t.test('should throw an error on 500', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, {})
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {
@@ -54,10 +54,10 @@ await t.test('deleteKv', async (t) => {
   })
 
   await t.test('should not break strage error on not JSON', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, '{')
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {

--- a/tests/getKv.test.ts
+++ b/tests/getKv.test.ts
@@ -1,8 +1,8 @@
 import t from 'node:test'
 import assert from 'node:assert'
 
-import { CloudFlareApi } from '../src/index.js'
-import { buildFakeCloudFlareServer } from './helper.js'
+import { CloudflareApi } from '../src/index.js'
+import { buildFakeCloudflareServer } from './helper.js'
 
 const API_KEY = 'a-fake-api-key'
 const ACCOUNT_ID = '123'
@@ -11,10 +11,10 @@ const KEY = '789'
 
 await t.test('getKv', async (t) => {
   await t.test('should get kv as json', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('GET', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { foo: 'bar' })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     const obj = await workerKv.getKv(KEY, 'json')
@@ -26,10 +26,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should get kv as json', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('GET', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { foo: 'bar' })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     const obj = await workerKv.getKv(KEY, 'text')
@@ -41,10 +41,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should get kv as arrayBuffer', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('GET', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, Buffer.from([1, 2, 3]))
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     const obj = await workerKv.getKv(KEY, 'arrayBuffer')
@@ -56,10 +56,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should get kv as blob', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('GET', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, Buffer.from([1, 2, 3]))
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     const obj = await workerKv.getKv(KEY, 'blob')
@@ -73,10 +73,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should get kv as response', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('GET', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { foo: 'bar' })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     const response = await workerKv.getKv(KEY, 'response')
@@ -89,10 +89,10 @@ await t.test('getKv', async (t) => {
 
   /*
   await t.test('should throw an error on success: false', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: false })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {
@@ -104,10 +104,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should throw an error on 500', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, {})
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {
@@ -119,10 +119,10 @@ await t.test('getKv', async (t) => {
   })
 
   await t.test('should not break strage error on not JSON', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('DELETE', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, '{')
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.deleteKv(KEY), err => {

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -10,7 +10,7 @@ declare module 'fastify' {
   }
 }
 
-export async function buildFakeCloudFlareServer (t: any, apiKey: string): Promise<Fastify.FastifyInstance> {
+export async function buildFakeCloudflareServer (t: any, apiKey: string): Promise<Fastify.FastifyInstance> {
   const server = Fastify({
     logger: {
       level: 'error'

--- a/tests/uploadKv.test.ts
+++ b/tests/uploadKv.test.ts
@@ -1,8 +1,8 @@
 import t from 'node:test'
 import assert from 'node:assert'
 
-import { CloudFlareApi } from '../src/index.js'
-import { buildFakeCloudFlareServer } from './helper.js'
+import { CloudflareApi } from '../src/index.js'
+import { buildFakeCloudflareServer } from './helper.js'
 
 const API_KEY = 'a-fake-api-key'
 const ACCOUNT_ID = '123'
@@ -13,10 +13,10 @@ const VALUE_BLOB = new Blob([Buffer.from([1, 2, 3])])
 
 await t.test('uploadKv', async (t) => {
   await t.test('should upload string kv', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('PUT', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: true })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await workerKv.uploadKv(KEY, VALUE)
@@ -28,10 +28,10 @@ await t.test('uploadKv', async (t) => {
   })
 
   await t.test('should upload blob kv', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('PUT', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: true })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await workerKv.uploadKv(KEY, VALUE_BLOB)
@@ -43,10 +43,10 @@ await t.test('uploadKv', async (t) => {
   })
 
   await t.test('should throw an error on success: false', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('PUT', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 200, { success: false })
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.uploadKv(KEY, 'value'), err => {
@@ -58,10 +58,10 @@ await t.test('uploadKv', async (t) => {
   })
 
   await t.test('should throw an error on 500', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('PUT', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, {})
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.uploadKv(KEY, 'value'), err => {
@@ -73,10 +73,10 @@ await t.test('uploadKv', async (t) => {
   })
 
   await t.test('should not break strage error on not JSON', async (t) => {
-    const fakeServer = await buildFakeCloudFlareServer(t, API_KEY)
+    const fakeServer = await buildFakeCloudflareServer(t, API_KEY)
     fakeServer.expectInvocation('PUT', `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${KEY}`, 500, '{')
 
-    const api = new CloudFlareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
+    const api = new CloudflareApi({ apiKey: API_KEY, url: fakeServer.getBaseUrl() })
     const workerKv = api.workerKv(ACCOUNT_ID, NAMESPACE_ID)
 
     await assert.rejects(workerKv.uploadKv(KEY, 'value'), err => {


### PR DESCRIPTION
This PR fixes the capitalisation of Cloudflare. While it started as CloudFlare, they've changed to Cloudflare several years ago. https://developers.cloudflare.com/style-guide/grammar/parts-of-speech/capitalization/

Import and use `CloudflareApi` instead of `CloudFlareApi`

```diff
- import { CloudFlareApi } from '@orama/cloudflare-api';
+ import { CloudflareApi } from '@orama/cloudflare-api';

- const api = new CloudFlareApi({ apiKey })
+ const api = new CloudflareApi({ apiKey })
```

This PR is a breaking change.